### PR TITLE
Update 2024

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,15 +10,15 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Generate PDF
       uses: dante-ev/latex-action@latest
       with:
         root_file: luxstat.tex
     - name: Archive generated PDF
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: luxstat
         path: |

--- a/luxpaper.sty
+++ b/luxpaper.sty
@@ -127,8 +127,7 @@
 \fancyhead[C]{}
 \fancyhead[R]{\includegraphics[scale=0.2]{lux_logo.pdf}}
 
-\fancyfoot[L]{Anja Zimmermann, Raphael Theiler} % = Name des Autors
-\fancyfoot[C]{\today} % = Datum (heute)
+\fancyfoot[L]{\today} % = Datum (heute)
 \fancyfoot[R]{\thepage} % = Seitenzahl
 
 \renewcommand{\footrulewidth}{0.4pt}	% Fusszeilenlinie

--- a/luxstat.tex
+++ b/luxstat.tex
@@ -59,7 +59,7 @@ von quelloffenen Systemen zu ermöglichen und zu erleichtern
 
 \luxarticle
 Der Verein besteht aus Aktivmitgliedern, Passivmitgliedern, 
-Ehrenmitgliedern und Gönnern. Als Mitglieder:innen können alle
+Ehrenmitgliedern und Gönnern. Als Mitglieder können alle
 natürlichen und juristischen Personen aufgenommen werden.
 
 \subsection{Aufnahme}
@@ -67,7 +67,7 @@ natürlichen und juristischen Personen aufgenommen werden.
 \luxarticle
 Die Mitgliedschaft wird mit schriftlicher oder mündlicher 
 Beitrittserklärung und durch Bezahlen des
-Mitglieder:innenbeitrages erworben.
+Mitgliederbeitrages erworben.
 
 \subsection{Erlöschen der Mitgliedschaft}
 
@@ -88,9 +88,9 @@ Vorstand auf Ende des Kalenderjahres möglich.
 \subsection{Ausschluss}
 
 \luxarticle
-Mitglieder:innen, deren Verhalten den Statuten widerspricht oder
+Mitglieder, deren Verhalten den Statuten widerspricht oder
 den Vereinszwecken abträglich ist oder die ihren
-Mitglieder:innenbeitrag trotz Mahnung nicht bezahlen, werden durch
+Mitgliederbeitrag trotz Mahnung nicht bezahlen, werden durch
 den Vorstand aus dem Verein ausgeschlossen. Der Ausschluss
 muss vom Vorstand nicht weiter begründet oder kommentiert
 werden.
@@ -134,7 +134,7 @@ Aktivmitgliederbeitrag.
 \subsection{Gönner:innen}
 
 \luxarticle
-Gönner:innen bzw. Sponsor:innen sind alle Personen, Organisationen 
+Gönner:innen sind alle Personen, Organisationen 
 oder Firmen, welche die Ziele des Vereins akzeptieren und
 den Verein finanziell unterstützen möchten.
 
@@ -154,7 +154,7 @@ Das oberste Organ des Vereins ist die Generalversammlung.
 Die ordentliche Generalversammlung findet jährlich
 jeweils im ersten Quartal statt.
 
-Die Einladung an die Mitglieder:innen und Gönner:innen erfolgt 
+Die Einladung an die Mitglieder und Gönner:innen erfolgt 
 schriftlich mit der Traktandenliste mindestens 30 Tage im
 voraus.
 
@@ -173,16 +173,15 @@ Tage vor der Versammlung zugestellt wurden.
 \luxarticle
 Die Generalversammlung hat die folgenden Aufgaben:
 \begin{itemize}
-\item Wahl des Präsident:in, Vorstand sowie des
-Rechnungsrevisor:in
+\item Wahl des Vorstandes, des:der Präsident:in sowie
+des:der Rechnungsrevisor:in
 \item Festsetzung und Änderung der Statuten.
 \item Abnahme der Jahresrechnung und des Revisorenberichtes
-\item Kenntnisnahme des Jahresberichtes des Präsidenten:in
-oder des Vorstandes
-\item Entlastung des Vorstandes, des Kassiers:in und der 
-Rechnungsrevisoren
+\item Kenntnisnahme des Jahresberichtes des Vorstandes
+\item Entlastung des Vorstandes, des:der Kassiers:in und 
+der Rechnungsrevisor:innen
 \item Beschlussfassung über das Jahresbudget
-\item Festsetzung der Mitglieder:innenbeiträge
+\item Festsetzung der Mitgliederbeiträge
 \item Behandlung von Anträgen des Vorstandes oder von 
 Mitgliedern sowie der Ausschlussrekurse
 \item Auflösung des Vereins
@@ -198,7 +197,7 @@ Stichentscheid.
 \subsection{Vorstand}
 
 \luxarticle
-Der Vorstand besteht aus mindestens fünf gewählten 
+Der Vorstand besteht aus mindestens vier gewählten 
 Aktivmitgliedern.
 
 Er besteht namentlich aus:
@@ -207,7 +206,7 @@ Er besteht namentlich aus:
 \item Vizepräsident:in
 \item Kassier:in
 \item Aktuar:in
-\item Infrastrukturverantwortlicher:in
+\item Infrastrukturverantwortliche:r
 \end{itemize}
 
 Der Vorstand kann um weitere Rollen ergänzt werden. Diese können innerhalb vom Vorstand frei verteilt werden.
@@ -225,18 +224,17 @@ effektiven Spesen und Barauslagen für den Verein.
 
 \section{Finanzen}
 
-\subsection*{Artikel §21}
 \luxarticle
 Vorstandsmitglieder:innen können im Laufe des geltenden 
 Kalenderjahres über Finanzmittel in Höhe des zweifachen
-Mitglieder:innenbeitrages frei verfügen. Überschreitungen sind
+Mitgliederbeitrages frei verfügen. Überschreitungen sind
 durch eine Generalversammlung zu genehmigen.
 
 \subsection{Unterschrift}
 
 \luxarticle
 Für den laufenden Geldverkehr zeichnet der:die Präsident:in oder 
-Kassier:in mit Einzelunterschrift.
+der:die Kassier:in mit Einzelunterschrift.
 
 \subsection{Rechnungswesen}
 
@@ -248,7 +246,7 @@ eröffnen. Der:die Kassier:in führt die Buchhaltung.
 \luxarticle
 Der Verein finanziert sich aus folgenden Mitteln:
 \begin{itemize}
-\item Jahresbeiträge der Mitglieder:innen
+\item Jahresbeiträge der Mitglieder
 \item Spenden und Gönner:innenbeiträge
 \item Erlöse aus Aktionen, Projekten und Veranstaltungen
 \item Erträge des Vereinsvermögens
@@ -258,26 +256,26 @@ Der Verein finanziert sich aus folgenden Mitteln:
 Die Generalversammlung legt die Höhe der Jahresbeiträge 
 für die Aktiv- und Passivmitglieder:innen fest.
 
-\subsection{Mitglieder:innenbeiträge}
+\subsection{Mitgliederbeiträge}
 
 \luxarticle
-Die Mitglieder:innenbeiträge sind innerhalb von 60 Tagen nach der 
+Die Mitgliederbeiträge sind innerhalb von 60 Tagen nach der 
 Generalversammlung zu bezahlen.
 
-Bezahlte Mitglieder:innenbeiträge werden bei Austritt oder 
+Bezahlte Mitgliederbeiträge werden bei Austritt oder 
 Ausschluss nicht zurückerstattet.
 
 \subsection{Haftung}
 
 \luxarticle
 Der Verein haftet nur mit dem Vereinsvermögen. Eine
-persönliche Haftung der Mitglieder:innen ist ausdrücklich
+persönliche Haftung der Mitglieder ist ausdrücklich
 ausgeschlossen.
 
 \subsection{Vereinsvermögen}
 
 \luxarticle
-Austretende oder ausgeschlossene Mitglieder:innen haben keinen 
+Austretende oder ausgeschlossene Mitglieder haben keinen 
 Anspruch auf Teile des Vereinsvermögens.
 
 \section{Statuten}
@@ -288,7 +286,7 @@ Generalversammlung zu genehmigen.
 
 Abänderungsvorschläge müssen schriftlich vorliegen.
 Zur Genehmigung von Statutenänderungen ist die absolute
-Mehrheit der anwesenden, stimmberechtigten Mitglieder:innen
+Mehrheit der anwesenden, stimmberechtigten Mitglieder
 erforderlich.
 
 \section{Auflösung des Vereins}
@@ -302,7 +300,7 @@ anwesend sind.
 
 Trifft dies nicht zu, so ist innerhalb von vier Wochen eine 
 zweite Generalversammlung einzuberufen, die ohne
-Rücksicht auf die Zahl der anwesenden Mitglieder:innen
+Rücksicht auf die Zahl der anwesenden Mitglieder
 beschlussfähig ist.
 
 \section{Schlussbestimmungen}

--- a/luxstat.tex
+++ b/luxstat.tex
@@ -116,13 +116,13 @@ der Generalversammlung beschlossenen
 Passivmitgliederbeitrag bezahlen.
 
 \luxarticle
-Passivmitglieder:innen werden zu der Generalversammlung 
+Passivmitglieder werden zu der Generalversammlung 
 eingeladen, haben jedoch kein Stimm- und Wahlrecht.
 
 \subsection{Ehrenmitglieder}
 
 \luxarticle
-Ehrenmitglieder:innen sind Personen, welche sich durch
+Ehrenmitglieder sind Personen, welche sich durch
 persönliche oder finanzielle Leistungen für den Verein besonders
 eingesetzt haben.
 
@@ -179,7 +179,7 @@ des:der Rechnungsrevisor:in
 \item Abnahme der Jahresrechnung und des Revisorenberichtes
 \item Kenntnisnahme des Jahresberichtes des Vorstandes
 \item Entlastung des Vorstandes, des:der Kassiers:in und 
-der Rechnungsrevisor:innen
+der Rechnungsrevisoren:innen
 \item Beschlussfassung über das Jahresbudget
 \item Festsetzung der Mitgliederbeiträge
 \item Behandlung von Anträgen des Vorstandes oder von 
@@ -218,14 +218,14 @@ ist nach Ablauf derselben wieder wählbar.
 
 Er ist berechtigt, in der Zwischenzeit entstandene Vakanzen 
 bis zur nächsten Generalversammlung provisorisch zu
-besetzen. Die Vorstandsmitglieder:innen sind ehrenamtlich tätig
+besetzen. Die Vorstandsmitglieder sind ehrenamtlich tätig
 und haben grundsätzlich nur Anspruch auf Entschädigung ihrer
 effektiven Spesen und Barauslagen für den Verein.
 
 \section{Finanzen}
 
 \luxarticle
-Vorstandsmitglieder:innen können im Laufe des geltenden 
+Vorstandsmitglieder können im Laufe des geltenden 
 Kalenderjahres über Finanzmittel in Höhe des zweifachen
 Mitgliederbeitrages frei verfügen. Überschreitungen sind
 durch eine Generalversammlung zu genehmigen.
@@ -254,7 +254,7 @@ Der Verein finanziert sich aus folgenden Mitteln:
  
 \luxarticle
 Die Generalversammlung legt die Höhe der Jahresbeiträge 
-für die Aktiv- und Passivmitglieder:innen fest.
+für die Aktiv- und Passivmitglieder fest.
 
 \subsection{Mitgliederbeiträge}
 

--- a/luxstat.tex
+++ b/luxstat.tex
@@ -122,8 +122,8 @@ eingeladen, haben jedoch kein Stimm- und Wahlrecht.
 \subsection{Ehrenmitglieder}
 
 \luxarticle
-Ehrenmitglieder sind Personen, welche sich durch
-persönliche oder finanzielle Leistungen für den Verein besonders
+Ehrenmitglieder sind Personen, welche sich durch persönliche
+oder finanzielle Leistungen für den Verein besonders
 eingesetzt haben.
 
 Sie können von einer Generalversammlung auf Antrag 

--- a/luxstat.tex
+++ b/luxstat.tex
@@ -110,7 +110,7 @@ Vertretungen sind nicht möglich.
 %\textit{Dieser Artikel ist in den Statuten nicht vorhanden (Quelle: www.luxeria.ch)}
 
 \luxarticle
-Passivmitglieder:innen sind natürliche oder juristische Personen, 
+Passivmitglieder sind natürliche oder juristische Personen, 
 welche die Mitgliedschaft wünschen und den jährlichen, von
 der Generalversammlung beschlossenen
 Passivmitgliederbeitrag bezahlen.

--- a/luxstat.tex
+++ b/luxstat.tex
@@ -174,7 +174,7 @@ Tage vor der Versammlung zugestellt wurden.
 Die Generalversammlung hat die folgenden Aufgaben:
 \begin{itemize}
 \item Wahl des Vorstandes, des:der Präsident:in sowie
-des:der Rechnungsrevisor:in
+des:der Rechnungsrevisors:in
 \item Festsetzung und Änderung der Statuten.
 \item Abnahme der Jahresrechnung und des Revisorenberichtes
 \item Kenntnisnahme des Jahresberichtes des Vorstandes

--- a/luxstat.tex
+++ b/luxstat.tex
@@ -2,7 +2,7 @@
                10pt,
                fleqn]{article}
 
-\author{Anja Zimmermann}
+\author{Cyrill Leutwiler}
 \title{Paper Manual}
 
 \usepackage{luxpaper}
@@ -14,21 +14,15 @@
 \begin{document}
 \luxtitle{Statuten}                             % Dokumentenart
          {LuXeria Statuten}                     % Titel
-         {Anja Zimmermann}   % Autor
+         {Vorstand}                             % Autor
          {Adligenswil}                          % Ort
-         {2019}                                 % Jahr
+         {2024}                                 % Jahr
 
 \tableofcontents
 \newpage
 
 %%%%%%%%%%
 
-
-\section*{Präambel}
-Um die Lesbarkeit des vorliegenden Textes zu
-erleichtern, wird auf die Doppelformulierung weiblich /
-männlich verzichtet. Selbstverständlich sind in der
-verwendeten maskulinen Form Männer und Frauen inbegriffen.
 
 \section{Name, Sitz und Bestand}
 
@@ -65,7 +59,7 @@ von quelloffenen Systemen zu ermöglichen und zu erleichtern
 
 \luxarticle
 Der Verein besteht aus Aktivmitgliedern, Passivmitgliedern, 
-Ehrenmitgliedern und Gönnern. Als Mitglieder können alle
+Ehrenmitgliedern und Gönnern. Als Mitglieder:innen können alle
 natürlichen und juristischen Personen aufgenommen werden.
 
 \subsection{Aufnahme}
@@ -73,7 +67,7 @@ natürlichen und juristischen Personen aufgenommen werden.
 \luxarticle
 Die Mitgliedschaft wird mit schriftlicher oder mündlicher 
 Beitrittserklärung und durch Bezahlen des
-Mitgliederbeitrages erworben.
+Mitglieder:innenbeitrages erworben.
 
 \subsection{Erlöschen der Mitgliedschaft}
 
@@ -94,9 +88,9 @@ Vorstand auf Ende des Kalenderjahres möglich.
 \subsection{Ausschluss}
 
 \luxarticle
-Mitglieder, deren Verhalten den Statuten widerspricht oder
+Mitglieder:innen, deren Verhalten den Statuten widerspricht oder
 den Vereinszwecken abträglich ist oder die ihren
-Mitgliederbeitrag trotz Mahnung nicht bezahlen, werden durch
+Mitglieder:innenbeitrag trotz Mahnung nicht bezahlen, werden durch
 den Vorstand aus dem Verein ausgeschlossen. Der Ausschluss
 muss vom Vorstand nicht weiter begründet oder kommentiert
 werden.
@@ -116,31 +110,31 @@ Vertretungen sind nicht möglich.
 %\textit{Dieser Artikel ist in den Statuten nicht vorhanden (Quelle: www.luxeria.ch)}
 
 \luxarticle
-Passivmitglieder sind natürliche oder juristische Personen, 
+Passivmitglieder:innen sind natürliche oder juristische Personen, 
 welche die Mitgliedschaft wünschen und den jährlichen, von
-der Mitgliederversammlung beschlossenen
+der Generalversammlung beschlossenen
 Passivmitgliederbeitrag bezahlen.
 
 \luxarticle
-Passivmitglieder werden zu den Mitgliederversammlungen 
+Passivmitglieder:innen werden zu der Generalversammlung 
 eingeladen, haben jedoch kein Stimm- und Wahlrecht.
 
 \subsection{Ehrenmitglieder}
 
 \luxarticle
-Ehrenmitglieder sind Personen, welche sich durch persönliche
-oder finanzielle Leistungen für den Verein besonders
+Ehrenmitglieder:innen sind Personen, welche sich durch
+persönliche oder finanzielle Leistungen für den Verein besonders
 eingesetzt haben.
 
-Sie können von einer Mitgliederversammlung auf Antrag 
+Sie können von einer Generalversammlung auf Antrag 
 ernannt beziehungsweise aberkannt werden. Sie sind den
 Aktivmitgliedern gleichgestellt, bezahlen aber keinen
 Aktivmitgliederbeitrag.
 
-\subsection{Gönner}
+\subsection{Gönner:innen}
 
 \luxarticle
-Gönner bzw. Sponsoren sind alle Personen, Organisationen 
+Gönner:innen bzw. Sponsor:innen sind alle Personen, Organisationen 
 oder Firmen, welche die Ziele des Vereins akzeptieren und
 den Verein finanziell unterstützen möchten.
 
@@ -149,18 +143,18 @@ den Verein finanziell unterstützen möchten.
 \luxarticle
 Die Organe des Vereins sind:
 \begin{itemize}
-\item die Mitgliederversammlung
+\item die Generalversammlung
 \item der Vorstand
 \end{itemize}
 
-\subsection{Mitgliederversammlung}
+\subsection{Generalversammlung}
 
 \luxarticle
-Das oberste Organ des Vereins ist die Mitgliederversammlung.
-Die ordentliche Mitgliederversammlung findet jährlich
+Das oberste Organ des Vereins ist die Generalversammlung.
+Die ordentliche Generalversammlung findet jährlich
 jeweils im ersten Quartal statt.
 
-Die Einladung an die Mitglieder und Gönner erfolgt 
+Die Einladung an die Mitglieder:innen und Gönner:innen erfolgt 
 schriftlich mit der Traktandenliste mindestens 30 Tage im
 voraus.
 
@@ -169,7 +163,7 @@ sind, muss kein Beschluss gefasst werden.
 
 \luxarticle
 Jedes Mitglied hat das Recht, Anträge zuhanden der nächsten 
-Mitgliederversammlung zu stellen.
+Generalversammlung zu stellen.
 
 Derartige Anträge sind in die Traktandenliste aufzunehmen, 
 sofern sie dem Vorstand schriftlich und begründet bis 20
@@ -177,25 +171,25 @@ Tage vor der Versammlung zugestellt wurden.
 
 \newpage
 \luxarticle
-Die Mitgliederversammlung hat die folgenden Aufgaben:
+Die Generalversammlung hat die folgenden Aufgaben:
 \begin{itemize}
-\item Wahl des Präsidenten, des Vorstandes sowie des 
-Rechnungsrevisors
+\item Wahl des Präsident:in, Vorstand sowie des
+Rechnungsrevisor:in
 \item Festsetzung und Änderung der Statuten.
 \item Abnahme der Jahresrechnung und des Revisorenberichtes
-\item Kenntnisnahme des Jahresberichtes des Präsidenten 
+\item Kenntnisnahme des Jahresberichtes des Präsidenten:in
 oder des Vorstandes
-\item Entlastung des Vorstandes, des Kassiers und der 
+\item Entlastung des Vorstandes, des Kassiers:in und der 
 Rechnungsrevisoren
 \item Beschlussfassung über das Jahresbudget
-\item Festsetzung der Mitgliederbeiträge
+\item Festsetzung der Mitglieder:innenbeiträge
 \item Behandlung von Anträgen des Vorstandes oder von 
 Mitgliedern sowie der Ausschlussrekurse
 \item Auflösung des Vereins
 \end{itemize}
 
 \luxarticle
-An der Mitgliederversammlung besitzt jedes aktive Mitglied 
+An der Generalversammlung besitzt jedes aktive Mitglied 
 eine Stimme. Die Beschlussfassung erfolgt mit einfachem Mehr
 der anwesenden Stimmberechtigten. 
 Der Präsident bringt im Falle eines Gleichstandes den 
@@ -204,15 +198,16 @@ Stichentscheid.
 \subsection{Vorstand}
 
 \luxarticle
-Der Vorstand besteht aus mindestens vier gewählten 
+Der Vorstand besteht aus mindestens fünf gewählten 
 Aktivmitgliedern.
 
 Er besteht namentlich aus:
 \begin{itemize}
-\item Präsident
-\item Vizepräsident
-\item Kassier
-\item Aktuar
+\item Präsident:in
+\item Vizepräsident:in
+\item Kassier:in
+\item Aktuar:in
+\item Infrastrukturverantwortlicher:in
 \end{itemize}
 
 Der Vorstand kann um weitere Rollen ergänzt werden. Diese können innerhalb vom Vorstand frei verteilt werden.
@@ -223,8 +218,8 @@ Der Vorstand wird für die Dauer von einem Jahr gewählt und
 ist nach Ablauf derselben wieder wählbar.
 
 Er ist berechtigt, in der Zwischenzeit entstandene Vakanzen 
-bis zur nächsten Mitgliederversammlung provisorisch zu
-besetzen. Die Vorstandsmitglieder sind ehrenamtlich tätig
+bis zur nächsten Generalversammlung provisorisch zu
+besetzen. Die Vorstandsmitglieder:innen sind ehrenamtlich tätig
 und haben grundsätzlich nur Anspruch auf Entschädigung ihrer
 effektiven Spesen und Barauslagen für den Verein.
 
@@ -232,68 +227,68 @@ effektiven Spesen und Barauslagen für den Verein.
 
 \subsection*{Artikel §21}
 \luxarticle
-Vorstandsmitglieder können im Laufe des geltenden 
+Vorstandsmitglieder:innen können im Laufe des geltenden 
 Kalenderjahres über Finanzmittel in Höhe des zweifachen
-Mitgliederbeitrages frei verfügen. Überschreitungen sind
-durch eine Mitgliederversammlung zu genehmigen.
+Mitglieder:innenbeitrages frei verfügen. Überschreitungen sind
+durch eine Generalversammlung zu genehmigen.
 
 \subsection{Unterschrift}
 
 \luxarticle
-Für den laufenden Geldverkehr zeichnet der Präsident oder 
-der Kassier mit Einzelunterschrift.
+Für den laufenden Geldverkehr zeichnet der:die Präsident:in oder 
+Kassier:in mit Einzelunterschrift.
 
 \subsection{Rechnungswesen}
 
 \luxarticle
 Das Rechnungsjahr ist in der Regel ein Kalenderjahr. Für
 den Geldverkehr ist ein Post- und/oder Bankkonto zu
-eröffnen. Der Kassier führt die Buchhaltung.
+eröffnen. Der:die Kassier:in führt die Buchhaltung.
 
 \luxarticle
 Der Verein finanziert sich aus folgenden Mitteln:
 \begin{itemize}
-\item Jahresbeiträge der Mitglieder
-\item Spenden und Gönnerbeiträge
+\item Jahresbeiträge der Mitglieder:innen
+\item Spenden und Gönner:innenbeiträge
 \item Erlöse aus Aktionen, Projekten und Veranstaltungen
 \item Erträge des Vereinsvermögens
 \end{itemize}
  
 \luxarticle
-Die Mitgliederversammlung legt die Höhe der Jahresbeiträge 
-für die Aktiv- und Passivmitglieder fest.
+Die Generalversammlung legt die Höhe der Jahresbeiträge 
+für die Aktiv- und Passivmitglieder:innen fest.
 
-\subsection{Mitgliederbeiträge}
+\subsection{Mitglieder:innenbeiträge}
 
 \luxarticle
-Die Mitgliederbeiträge sind innerhalb von 60 Tagen nach der 
-Mitgliederversammlung zu bezahlen.
+Die Mitglieder:innenbeiträge sind innerhalb von 60 Tagen nach der 
+Generalversammlung zu bezahlen.
 
-Bezahlte Mitgliederbeiträge werden bei Austritt oder 
+Bezahlte Mitglieder:innenbeiträge werden bei Austritt oder 
 Ausschluss nicht zurückerstattet.
 
 \subsection{Haftung}
 
 \luxarticle
 Der Verein haftet nur mit dem Vereinsvermögen. Eine
-persönliche Haftung der Mitglieder ist ausdrücklich
+persönliche Haftung der Mitglieder:innen ist ausdrücklich
 ausgeschlossen.
 
 \subsection{Vereinsvermögen}
 
 \luxarticle
-Austretende oder ausgeschlossene Mitglieder haben keinen 
+Austretende oder ausgeschlossene Mitglieder:innen haben keinen 
 Anspruch auf Teile des Vereinsvermögens.
 
 \section{Statuten}
 
 \luxarticle
 Die Statuten sind von der Gründungs- oder 
-Mitgliederversammlung zu genehmigen.
+Generalversammlung zu genehmigen.
 
 Abänderungsvorschläge müssen schriftlich vorliegen.
 Zur Genehmigung von Statutenänderungen ist die absolute
-Mehrheit der anwesenden, stimmberechtigten Mitglieder
+Mehrheit der anwesenden, stimmberechtigten Mitglieder:innen
 erforderlich.
 
 \section{Auflösung des Vereins}
@@ -301,13 +296,13 @@ erforderlich.
 \luxarticle
 Die Auflösung des Vereins kann nur durch eine
 ausschliesslich zu diesem Zweck einberufene,
-ausserordentliche Mitgliederversammlung beschlossen werden,
-an der mindestens zwei Drittel der Aktivmitglieder anwesend
-sind.
+ausserordentliche Generalversammlung beschlossen werden,
+an der mindestens zwei Drittel der Aktivmitglieder:innen
+anwesend sind.
 
 Trifft dies nicht zu, so ist innerhalb von vier Wochen eine 
-zweite Mitgliederversammlung einzuberufen, die ohne
-Rücksicht auf die Zahl der anwesenden Mitglieder
+zweite Generalversammlung einzuberufen, die ohne
+Rücksicht auf die Zahl der anwesenden Mitglieder:innen
 beschlussfähig ist.
 
 \section{Schlussbestimmungen}
@@ -315,12 +310,12 @@ beschlussfähig ist.
 \luxarticle
 Im Falle der Liquidation muss das Vereinsvermögen einer oder
 mehreren gemeinnützigen Organisationen, welche den gleichen
-oder einen ähnlichen Zweck verfolgen überwiesen werden. Im
-Falle dass keine Einigung zu Stande kommt, wird das
+oder einen ähnlichen Zweck verfolgen, überwiesen werden. Im
+Falle, dass keine Einigung zu Stande kommt, wird das
 Vereinsvermögen der Gemeinde oder dem Amt überwiesen, in 
 welcher sich der Sitz des Vereins befindet.
 
-Die ausserordentliche Mitgliederversammlung legt die Details
+Die ausserordentliche Generalversammlung legt die Details
 dieses Beschlusses fest.
 
 \section{Inkrafttreten}
@@ -333,7 +328,7 @@ getreten.\newline\newline
 \indent \textbf{Präsident} & 
     \indent \indent \indent \indent \indent \indent &
         \textbf{Vizepräsident} \\
-\indent Anja Zimmermann     & 
+\indent Cyrill Leutwiler     & 
     \indent \indent \indent \indent \indent \indent &
         Raphael Theiler \\
 \end{tabular}


### PR DESCRIPTION
- Keine namentliche Nennungen wo nicht unbedingt notwendig
- Gender-neutrale schreibweise (und deswegen Präambel entfernt)
- Infrastrukturverantworliche:r explizit als Vorstandsamt aufgeführt
- Redundanter Untertitel `Artikel §21` entfernt
- `- Anja` und `+ Cyrill` Präsidialamt, update Jahr auf 2024 
- Drive-by updates für CI
- Drive-by Komma fix